### PR TITLE
feat: Update video titles and tutorial index logic

### DIFF
--- a/tutorials/index.html
+++ b/tutorials/index.html
@@ -240,8 +240,6 @@
                  color: var(--bg-color); /* Background color text for active in dark mode */
             }
         }
-
-
     </style>
 </head>
 <body>
@@ -266,124 +264,124 @@
         
         <h2>Available Tutorials</h2>
         <ul id="tutorialListUL">
-            <li><a href="videos/Tutorial-3D Porosity Analysis in Archaeological Ceramics to Reconstruct Production Methods and Performance-Chinese.html">3D Porosity Analysis in Archaeological Ceramics to Reconstruct Production Methods and Performance (Chinese)</a></li>
-            <li><a href="videos/Tutorial-3D Porosity Analysis in Archaeological Ceramics to Reconstruct Production Methods and Performance-English.html">3D Porosity Analysis in Archaeological Ceramics to Reconstruct Production Methods and Performance (English)</a></li>
-            <li><a href="videos/Tutorial-A Natural History Perspective_ Micro-CT Scanning at the University of Michigan Museum of Zoology-Chinese.html">A Natural History Perspective_ Micro-CT Scanning at the University of Michigan Museum of Zoology (Chinese)</a></li>
-            <li><a href="videos/Tutorial-A Natural History Perspective_ Micro-CT Scanning at the University of Michigan Museum of Zoology-English.html">A Natural History Perspective_ Micro-CT Scanning at the University of Michigan Museum of Zoology (English)</a></li>
-            <li><a href="videos/Tutorial-Additive Manufacturing Powder Characterization Using Dragonfly-Chinese.html">Additive Manufacturing Powder Characterization Using Dragonfly (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Additive Manufacturing Powder Characterization Using Dragonfly-English.html">Additive Manufacturing Powder Characterization Using Dragonfly (English)</a></li>
-            <li><a href="videos/Tutorial-Automation of NDT Inspection by Dragonfly Scripting and HPC Batch Processing-Chinese.html">Automation of NDT Inspection by Dragonfly Scripting and HPC Batch Processing (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Automation of NDT Inspection by Dragonfly Scripting and HPC Batch Processing-English.html">Automation of NDT Inspection by Dragonfly Scripting and HPC Batch Processing (English)</a></li>
-            <li><a href="videos/Tutorial-CAD Deviation of Additive Manufacturing Bracket Using Dragonfly-Chinese.html">CAD Deviation of Additive Manufacturing Bracket Using Dragonfly (Chinese)</a></li>
-            <li><a href="videos/Tutorial-CAD Deviation of Additive Manufacturing Bracket Using Dragonfly-English.html">CAD Deviation of Additive Manufacturing Bracket Using Dragonfly (English)</a></li>
-            <li><a href="videos/Tutorial-Computed Tomography for Industrial Inspection and Quality Control Powered by Dragonfly Software-Chinese.html">Computed Tomography for Industrial Inspection and Quality Control Powered by Dragonfly Software (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Computed Tomography for Industrial Inspection and Quality Control Powered by Dragonfly Software-English.html">Computed Tomography for Industrial Inspection and Quality Control Powered by Dragonfly Software (English)</a></li>
-            <li><a href="videos/Tutorial-Cone Beam CT Reconstruction in Dragonfly 2022.2-Chinese.html">Cone Beam CT Reconstruction in Dragonfly 2022.2 (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Cone Beam CT Reconstruction in Dragonfly 2022.2-English.html">Cone Beam CT Reconstruction in Dragonfly 2022.2 (English)</a></li>
-            <li><a href="videos/Tutorial-Crack Identification and Segmentation for NDT Using Dragonfly How-To Video-Chinese.html">Crack Identification and Segmentation for NDT Using Dragonfly How To Video (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Crack Identification and Segmentation for NDT Using Dragonfly How-To Video-English.html">Crack Identification and Segmentation for NDT Using Dragonfly How To Video (English)</a></li>
-            <li><a href="videos/Tutorial-Creating a volume-of-interest using Active Contour tool-Chinese.html">Creating a volume of interest using Active Contour tool (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Creating a volume-of-interest using Active Contour tool-English.html">Creating a volume of interest using Active Contour tool (English)</a></li>
-            <li><a href="videos/Tutorial-Decoding the Fossil Record_ The Benefits of AI in the Segmentation of Fossils-Chinese.html">Decoding the Fossil Record_ The Benefits of AI in the Segmentation of Fossils (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Decoding the Fossil Record_ The Benefits of AI in the Segmentation of Fossils-English.html">Decoding the Fossil Record_ The Benefits of AI in the Segmentation of Fossils (English)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly 2022.2 Feature _ Volume meshing of a walnut-Chinese.html">Dragonfly 2022.2 Feature _ Volume meshing of a walnut (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly 2022.2 Feature _ Volume meshing of a walnut-English.html">Dragonfly 2022.2 Feature _ Volume meshing of a walnut (English)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly 3D World _ AI solutions for individual battery anode-cathode overhang analysis-Chinese.html">Dragonfly 3D World _ AI solutions for individual battery anode cathode overhang analysis (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly 3D World _ AI solutions for individual battery anode-cathode overhang analysis-English.html">Dragonfly 3D World _ AI solutions for individual battery anode cathode overhang analysis (English)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly Daily 35 Workflows, Wizards, and Reports in Dragonfly (2020)-Chinese.html">Dragonfly Daily 35 Workflows, Wizards, and Reports in Dragonfly (2020) (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly Daily 35 Workflows, Wizards, and Reports in Dragonfly (2020)-English.html">Dragonfly Daily 35 Workflows, Wizards, and Reports in Dragonfly (2020) (English)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly Daily 36 CT Reconstruction in Dragonfly (2020)-Chinese.html">Dragonfly Daily 36 CT Reconstruction in Dragonfly (2020) (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly Daily 36 CT Reconstruction in Dragonfly (2020)-English.html">Dragonfly Daily 36 CT Reconstruction in Dragonfly (2020) (English)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly Daily 37 Distance Mapping in Dragonfly (2020)-Chinese.html">Dragonfly Daily 37 Distance Mapping in Dragonfly (2020) (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly Daily 37 Distance Mapping in Dragonfly (2020)-English.html">Dragonfly Daily 37 Distance Mapping in Dragonfly (2020) (English)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly Daily 38 Watershed Transform in Dragonfly (2020)-Chinese.html">Dragonfly Daily 38 Watershed Transform in Dragonfly (2020) (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly Daily 38 Watershed Transform in Dragonfly (2020)-English.html">Dragonfly Daily 38 Watershed Transform in Dragonfly (2020) (English)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly Daily 39 Cylinder Coordinate Transform in Dragonfly (2020)-Chinese.html">Dragonfly Daily 39 Cylinder Coordinate Transform in Dragonfly (2020) (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Dragonfly Daily 39 Cylinder Coordinate Transform in Dragonfly (2020)-English.html">Dragonfly Daily 39 Cylinder Coordinate Transform in Dragonfly (2020) (English)</a></li>
-            <li><a href="videos/Tutorial-How to use a pretrained deep learning model for additive manufacturing porosity-Chinese.html">How to use a pretrained deep learning model for additive manufacturing porosity (Chinese)</a></li>
-            <li><a href="videos/Tutorial-How to use a pretrained deep learning model for additive manufacturing porosity-English.html">How to use a pretrained deep learning model for additive manufacturing porosity (English)</a></li>
-            <li><a href="videos/Tutorial-How-to video_ CT based porosity analysis of concrete using Dragonfly-Chinese.html">How to video_ CT based porosity analysis of concrete using Dragonfly (Chinese)</a></li>
-            <li><a href="videos/Tutorial-How-to video_ CT based porosity analysis of concrete using Dragonfly-English.html">How to video_ CT based porosity analysis of concrete using Dragonfly (English)</a></li>
-            <li><a href="videos/Tutorial-How-to video_ CT image analysis for battery inspection using Dragonfly-Chinese.html">How to video_ CT image analysis for battery inspection using Dragonfly (Chinese)</a></li>
-            <li><a href="videos/Tutorial-How-to video_ CT image analysis for battery inspection using Dragonfly-English.html">How to video_ CT image analysis for battery inspection using Dragonfly (English)</a></li>
-            <li><a href="videos/Tutorial-Image Import in Dragonfly-Chinese.html">Image Import in Dragonfly (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Image Import in Dragonfly-English.html">Image Import in Dragonfly (English)</a></li>
-            <li><a href="videos/Tutorial-In Vivo and Specimen Imaging at the Center for Molecular and Genomic Imaging-Chinese.html">In Vivo and Specimen Imaging at the Center for Molecular and Genomic Imaging (Chinese)</a></li>
-            <li><a href="videos/Tutorial-In Vivo and Specimen Imaging at the Center for Molecular and Genomic Imaging-English.html">In Vivo and Specimen Imaging at the Center for Molecular and Genomic Imaging (English)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 0_ Introduction-Chinese.html">July 2022 Workshop Video 0_ Introduction (Chinese)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 0_ Introduction-English.html">July 2022 Workshop Video 0_ Introduction (English)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 10_ Segmentation Wizard Part 2-Chinese.html">July 2022 Workshop Video 10_ Segmentation Wizard Part 2 (Chinese)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 10_ Segmentation Wizard Part 2-English.html">July 2022 Workshop Video 10_ Segmentation Wizard Part 2 (English)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 11_ Deep learning tool-Chinese.html">July 2022 Workshop Video 11_ Deep learning tool (Chinese)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 11_ Deep learning tool-English.html">July 2022 Workshop Video 11_ Deep learning tool (English)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 1_ Introduction to Dragonfly User Interface-Chinese.html">July 2022 Workshop Video 1_ Introduction to Dragonfly User Interface (Chinese)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 1_ Introduction to Dragonfly User Interface-English.html">July 2022 Workshop Video 1_ Introduction to Dragonfly User Interface (English)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 2_ Data Import and Basic Operations-Chinese.html">July 2022 Workshop Video 2_ Data Import and Basic Operations (Chinese)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 2_ Data Import and Basic Operations-English.html">July 2022 Workshop Video 2_ Data Import and Basic Operations (English)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 3_ Display Tools and Window Leveling-Chinese.html">July 2022 Workshop Video 3_ Display Tools and Window Leveling (Chinese)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 3_ Display Tools and Window Leveling-English.html">July 2022 Workshop Video 3_ Display Tools and Window Leveling (English)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 4_ Image Filtering-Chinese.html">July 2022 Workshop Video 4_ Image Filtering (Chinese)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 4_ Image Filtering-English.html">July 2022 Workshop Video 4_ Image Filtering (English)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 5_ Defining Region of Interest (ROI) and Basic Segmentation Tools-Chinese.html">July 2022 Workshop Video 5_ Defining Region of Interest (ROI) and Basic Segmentation Tools (Chinese)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 5_ Defining Region of Interest (ROI) and Basic Segmentation Tools-English.html">July 2022 Workshop Video 5_ Defining Region of Interest (ROI) and Basic Segmentation Tools (English)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 6_ Measuring Tools-Chinese.html">July 2022 Workshop Video 6_ Measuring Tools (Chinese)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 6_ Measuring Tools-English.html">July 2022 Workshop Video 6_ Measuring Tools (English)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 7_ Image Registration-Chinese.html">July 2022 Workshop Video 7_ Image Registration (Chinese)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 7_ Image Registration-English.html">July 2022 Workshop Video 7_ Image Registration (English)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 8_ AI Based Segmentation Part 1-Chinese.html">July 2022 Workshop Video 8_ AI Based Segmentation Part 1 (Chinese)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 8_ AI Based Segmentation Part 1-English.html">July 2022 Workshop Video 8_ AI Based Segmentation Part 1 (English)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 9_ Segmentation Wizard Part 1-Chinese.html">July 2022 Workshop Video 9_ Segmentation Wizard Part 1 (Chinese)</a></li>
-            <li><a href="videos/Tutorial-July 2022 Workshop Video 9_ Segmentation Wizard Part 1-English.html">July 2022 Workshop Video 9_ Segmentation Wizard Part 1 (English)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Basic Operations-Chinese.html">Learn Dragonfly_ Basic Operations (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Basic Operations-English.html">Learn Dragonfly_ Basic Operations (English)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Deep Learning Segmentation-Chinese.html">Learn Dragonfly_ Deep Learning Segmentation (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Deep Learning Segmentation-English.html">Learn Dragonfly_ Deep Learning Segmentation (English)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Image Filtering and Denoising-Chinese.html">Learn Dragonfly_ Image Filtering and Denoising (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Image Filtering and Denoising-English.html">Learn Dragonfly_ Image Filtering and Denoising (English)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Image Registration-Chinese.html">Learn Dragonfly_ Image Registration (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Image Registration-English.html">Learn Dragonfly_ Image Registration (English)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Image Segmentation Techniques-Chinese.html">Learn Dragonfly_ Image Segmentation Techniques (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Image Segmentation Techniques-English.html">Learn Dragonfly_ Image Segmentation Techniques (English)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Importing and Exporting Data-Chinese.html">Learn Dragonfly_ Importing and Exporting Data (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Importing and Exporting Data-English.html">Learn Dragonfly_ Importing and Exporting Data (English)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Introduction to the User Interface-Chinese.html">Learn Dragonfly_ Introduction to the User Interface (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Introduction to the User Interface-English.html">Learn Dragonfly_ Introduction to the User Interface (English)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Measurement and Analysis-Chinese.html">Learn Dragonfly_ Measurement and Analysis (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Measurement and Analysis-English.html">Learn Dragonfly_ Measurement and Analysis (English)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ ROI Creation and Manipulation-Chinese.html">Learn Dragonfly_ ROI Creation and Manipulation (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ ROI Creation and Manipulation-English.html">Learn Dragonfly_ ROI Creation and Manipulation (English)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Working with Meshes-Chinese.html">Learn Dragonfly_ Working with Meshes (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Learn Dragonfly_ Working with Meshes-English.html">Learn Dragonfly_ Working with Meshes (English)</a></li>
-            <li><a href="videos/Tutorial-Materials Science Applications with Dragonfly Software-Chinese.html">Materials Science Applications with Dragonfly Software (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Materials Science Applications with Dragonfly Software-English.html">Materials Science Applications with Dragonfly Software (English)</a></li>
-            <li><a href="videos/Tutorial-Multi-Scale Correlative Tomography using Dragonfly Software-Chinese.html">Multi Scale Correlative Tomography using Dragonfly Software (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Multi-Scale Correlative Tomography using Dragonfly Software-English.html">Multi Scale Correlative Tomography using Dragonfly Software (English)</a></li>
-            <li><a href="videos/Tutorial-Navigation, slice views, 3D views, and basic interaction-Chinese.html">Navigation, slice views, 3D views, and basic interaction (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Navigation, slice views, 3D views, and basic interaction-English.html">Navigation, slice views, 3D views, and basic interaction (English)</a></li>
-            <li><a href="videos/Tutorial-Neuroscience Research with Dragonfly_ Analyzing Brain Structures-Chinese.html">Neuroscience Research with Dragonfly_ Analyzing Brain Structures (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Neuroscience Research with Dragonfly_ Analyzing Brain Structures-English.html">Neuroscience Research with Dragonfly_ Analyzing Brain Structures (English)</a></li>
-            <li><a href="videos/Tutorial-Porosity Analysis of Casting Components Using Dragonfly-Chinese.html">Porosity Analysis of Casting Components Using Dragonfly (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Porosity Analysis of Casting Components Using Dragonfly-English.html">Porosity Analysis of Casting Components Using Dragonfly (English)</a></li>
-            <li><a href="videos/Tutorial-Python scripting in Dragonfly-Chinese.html">Python scripting in Dragonfly (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Python scripting in Dragonfly-English.html">Python scripting in Dragonfly (English)</a></li>
-            <li><a href="videos/Tutorial-Quantitative Analysis of Fiber Composites with Dragonfly-Chinese.html">Quantitative Analysis of Fiber Composites with Dragonfly (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Quantitative Analysis of Fiber Composites with Dragonfly-English.html">Quantitative Analysis of Fiber Composites with Dragonfly (English)</a></li>
-            <li><a href="videos/Tutorial-ROI tools and their use cases-Chinese.html">ROI tools and their use cases (Chinese)</a></li>
-            <li><a href="videos/Tutorial-ROI tools and their use cases-English.html">ROI tools and their use cases (English)</a></li>
-            <li><a href="videos/Tutorial-Segmentation Part 1_ Thresholding and basic tools-Chinese.html">Segmentation Part 1_ Thresholding and basic tools (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Segmentation Part 1_ Thresholding and basic tools-English.html">Segmentation Part 1_ Thresholding and basic tools (English)</a></li>
-            <li><a href="videos/Tutorial-Segmentation Part 2_Watershed and other automated tools-Chinese.html">Segmentation Part 2_Watershed and other automated tools (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Segmentation Part 2_Watershed and other automated tools-English.html">Segmentation Part 2_Watershed and other automated tools (English)</a></li>
-            <li><a href="videos/Tutorial-Segmentation Part 3_ Deep Learning-Chinese.html">Segmentation Part 3_ Deep Learning (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Segmentation Part 3_ Deep Learning-English.html">Segmentation Part 3_ Deep Learning (English)</a></li>
-            <li><a href="videos/Tutorial-Segmentation of pores in a cast aluminum alloy using Deep Learning-Chinese.html">Segmentation of pores in a cast aluminum alloy using Deep Learning (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Segmentation of pores in a cast aluminum alloy using Deep Learning-English.html">Segmentation of pores in a cast aluminum alloy using Deep Learning (English)</a></li>
-            <li><a href="videos/Tutorial-The Active Contour tool for segmentation-Chinese.html">The Active Contour tool for segmentation (Chinese)</a></li>
-            <li><a href="videos/Tutorial-The Active Contour tool for segmentation-English.html">The Active Contour tool for segmentation (English)</a></li>
-            <li><a href="videos/Tutorial-Using the Image Channel Composition Tool in Dragonfly-Chinese.html">Using the Image Channel Composition Tool in Dragonfly (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Using the Image Channel Composition Tool in Dragonfly-English.html">Using the Image Channel Composition Tool in Dragonfly (English)</a></li>
-            <li><a href="videos/Tutorial-Working with DICOM data in Dragonfly-Chinese.html">Working with DICOM data in Dragonfly (Chinese)</a></li>
-            <li><a href="videos/Tutorial-Working with DICOM data in Dragonfly-English.html">Working with DICOM data in Dragonfly (English)</a></li>
+            <li><a href="videos/Tutorial-3D Porosity Analysis in Archaeological Ceramics to Reconstruct Production Methods and Performance-Chinese.html">3D Porosity Analysis in Archaeological Ceramics to Reconstruct Production Methods and Performance (中文解读)</a></li>
+            <li><a href="videos/Tutorial-3D Porosity Analysis in Archaeological Ceramics to Reconstruct Production Methods and Performance-English.html">3D Porosity Analysis in Archaeological Ceramics to Reconstruct Production Methods and Performance</a></li>
+            <li><a href="videos/Tutorial-A Natural History Perspective_ Micro-CT Scanning at the University of Michigan Museum of Zoology-Chinese.html">A Natural History Perspective_ Micro-CT Scanning at the University of Michigan Museum of Zoology (中文解读)</a></li>
+            <li><a href="videos/Tutorial-A Natural History Perspective_ Micro-CT Scanning at the University of Michigan Museum of Zoology-English.html">A Natural History Perspective_ Micro-CT Scanning at the University of Michigan Museum of Zoology</a></li>
+            <li><a href="videos/Tutorial-Additive Manufacturing Powder Characterization Using Dragonfly-Chinese.html">Additive Manufacturing Powder Characterization Using Dragonfly (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Additive Manufacturing Powder Characterization Using Dragonfly-English.html">Additive Manufacturing Powder Characterization Using Dragonfly</a></li>
+            <li><a href="videos/Tutorial-Automation of NDT Inspection by Dragonfly Scripting and HPC Batch Processing-Chinese.html">Automation of NDT Inspection by Dragonfly Scripting and HPC Batch Processing (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Automation of NDT Inspection by Dragonfly Scripting and HPC Batch Processing-English.html">Automation of NDT Inspection by Dragonfly Scripting and HPC Batch Processing</a></li>
+            <li><a href="videos/Tutorial-CAD Deviation of Additive Manufacturing Bracket Using Dragonfly-Chinese.html">CAD Deviation of Additive Manufacturing Bracket Using Dragonfly (中文解读)</a></li>
+            <li><a href="videos/Tutorial-CAD Deviation of Additive Manufacturing Bracket Using Dragonfly-English.html">CAD Deviation of Additive Manufacturing Bracket Using Dragonfly</a></li>
+            <li><a href="videos/Tutorial-Computed Tomography for Industrial Inspection and Quality Control Powered by Dragonfly Software-Chinese.html">Computed Tomography for Industrial Inspection and Quality Control Powered by Dragonfly Software (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Computed Tomography for Industrial Inspection and Quality Control Powered by Dragonfly Software-English.html">Computed Tomography for Industrial Inspection and Quality Control Powered by Dragonfly Software</a></li>
+            <li><a href="videos/Tutorial-Cone Beam CT Reconstruction in Dragonfly 2022.2-Chinese.html">Cone Beam CT Reconstruction in Dragonfly 2022.2 (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Cone Beam CT Reconstruction in Dragonfly 2022.2-English.html">Cone Beam CT Reconstruction in Dragonfly 2022.2</a></li>
+            <li><a href="videos/Tutorial-Crack Identification and Segmentation for NDT Using Dragonfly How-To Video-Chinese.html">Crack Identification and Segmentation for NDT Using Dragonfly How To Video (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Crack Identification and Segmentation for NDT Using Dragonfly How-To Video-English.html">Crack Identification and Segmentation for NDT Using Dragonfly How To Video</a></li>
+            <li><a href="videos/Tutorial-Creating a volume-of-interest using Active Contour tool-Chinese.html">Creating a volume of interest using Active Contour tool (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Creating a volume-of-interest using Active Contour tool-English.html">Creating a volume of interest using Active Contour tool</a></li>
+            <li><a href="videos/Tutorial-Decoding the Fossil Record_ The Benefits of AI in the Segmentation of Fossils-Chinese.html">Decoding the Fossil Record_ The Benefits of AI in the Segmentation of Fossils (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Decoding the Fossil Record_ The Benefits of AI in the Segmentation of Fossils-English.html">Decoding the Fossil Record_ The Benefits of AI in the Segmentation of Fossils</a></li>
+            <li><a href="videos/Tutorial-Dragonfly 2022.2 Feature _ Volume meshing of a walnut-Chinese.html">Dragonfly 2022.2 Feature _ Volume meshing of a walnut (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Dragonfly 2022.2 Feature _ Volume meshing of a walnut-English.html">Dragonfly 2022.2 Feature _ Volume meshing of a walnut</a></li>
+            <li><a href="videos/Tutorial-Dragonfly 3D World _ AI solutions for individual battery anode-cathode overhang analysis-Chinese.html">Dragonfly 3D World _ AI solutions for individual battery anode cathode overhang analysis (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Dragonfly 3D World _ AI solutions for individual battery anode-cathode overhang analysis-English.html">Dragonfly 3D World _ AI solutions for individual battery anode cathode overhang analysis</a></li>
+            <li><a href="videos/Tutorial-Dragonfly Daily 35 Workflows, Wizards, and Reports in Dragonfly (2020)-Chinese.html">Dragonfly Daily 35 Workflows, Wizards, and Reports in Dragonfly (2020) (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Dragonfly Daily 35 Workflows, Wizards, and Reports in Dragonfly (2020)-English.html">Dragonfly Daily 35 Workflows, Wizards, and Reports in Dragonfly (2020)</a></li>
+            <li><a href="videos/Tutorial-Dragonfly Daily 36 CT Reconstruction in Dragonfly (2020)-Chinese.html">Dragonfly Daily 36 CT Reconstruction in Dragonfly (2020) (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Dragonfly Daily 36 CT Reconstruction in Dragonfly (2020)-English.html">Dragonfly Daily 36 CT Reconstruction in Dragonfly (2020)</a></li>
+            <li><a href="videos/Tutorial-Dragonfly Daily 37 Distance Mapping in Dragonfly (2020)-Chinese.html">Dragonfly Daily 37 Distance Mapping in Dragonfly (2020) (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Dragonfly Daily 37 Distance Mapping in Dragonfly (2020)-English.html">Dragonfly Daily 37 Distance Mapping in Dragonfly (2020)</a></li>
+            <li><a href="videos/Tutorial-Dragonfly Daily 38 Watershed Transform in Dragonfly (2020)-Chinese.html">Dragonfly Daily 38 Watershed Transform in Dragonfly (2020) (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Dragonfly Daily 38 Watershed Transform in Dragonfly (2020)-English.html">Dragonfly Daily 38 Watershed Transform in Dragonfly (2020)</a></li>
+            <li><a href="videos/Tutorial-Dragonfly Daily 39 Cylinder Coordinate Transform in Dragonfly (2020)-Chinese.html">Dragonfly Daily 39 Cylinder Coordinate Transform in Dragonfly (2020) (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Dragonfly Daily 39 Cylinder Coordinate Transform in Dragonfly (2020)-English.html">Dragonfly Daily 39 Cylinder Coordinate Transform in Dragonfly (2020)</a></li>
+            <li><a href="videos/Tutorial-How to use a pretrained deep learning model for additive manufacturing porosity-Chinese.html">How to use a pretrained deep learning model for additive manufacturing porosity (中文解读)</a></li>
+            <li><a href="videos/Tutorial-How to use a pretrained deep learning model for additive manufacturing porosity-English.html">How to use a pretrained deep learning model for additive manufacturing porosity</a></li>
+            <li><a href="videos/Tutorial-How-to video_ CT based porosity analysis of concrete using Dragonfly-Chinese.html">How to video_ CT based porosity analysis of concrete using Dragonfly (中文解读)</a></li>
+            <li><a href="videos/Tutorial-How-to video_ CT based porosity analysis of concrete using Dragonfly-English.html">How to video_ CT based porosity analysis of concrete using Dragonfly</a></li>
+            <li><a href="videos/Tutorial-How-to video_ CT image analysis for battery inspection using Dragonfly-Chinese.html">How to video_ CT image analysis for battery inspection using Dragonfly (中文解读)</a></li>
+            <li><a href="videos/Tutorial-How-to video_ CT image analysis for battery inspection using Dragonfly-English.html">How to video_ CT image analysis for battery inspection using Dragonfly</a></li>
+            <li><a href="videos/Tutorial-Image Import in Dragonfly-Chinese.html">Image Import in Dragonfly (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Image Import in Dragonfly-English.html">Image Import in Dragonfly</a></li>
+            <li><a href="videos/Tutorial-In Vivo and Specimen Imaging at the Center for Molecular and Genomic Imaging-Chinese.html">In Vivo and Specimen Imaging at the Center for Molecular and Genomic Imaging (中文解读)</a></li>
+            <li><a href="videos/Tutorial-In Vivo and Specimen Imaging at the Center for Molecular and Genomic Imaging-English.html">In Vivo and Specimen Imaging at the Center for Molecular and Genomic Imaging</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 0_ Introduction-Chinese.html">July 2022 Workshop Video 0_ Introduction (中文解读)</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 0_ Introduction-English.html">July 2022 Workshop Video 0_ Introduction</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 10_ Segmentation Wizard Part 2-Chinese.html">July 2022 Workshop Video 10_ Segmentation Wizard Part 2 (中文解读)</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 10_ Segmentation Wizard Part 2-English.html">July 2022 Workshop Video 10_ Segmentation Wizard Part 2</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 11_ Deep learning tool-Chinese.html">July 2022 Workshop Video 11_ Deep learning tool (中文解读)</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 11_ Deep learning tool-English.html">July 2022 Workshop Video 11_ Deep learning tool</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 1_ Introduction to Dragonfly User Interface-Chinese.html">July 2022 Workshop Video 1_ Introduction to Dragonfly User Interface (中文解读)</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 1_ Introduction to Dragonfly User Interface-English.html">July 2022 Workshop Video 1_ Introduction to Dragonfly User Interface</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 2_ Data Import and Basic Operations-Chinese.html">July 2022 Workshop Video 2_ Data Import and Basic Operations (中文解读)</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 2_ Data Import and Basic Operations-English.html">July 2022 Workshop Video 2_ Data Import and Basic Operations</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 3_ Display Tools and Window Leveling-Chinese.html">July 2022 Workshop Video 3_ Display Tools and Window Leveling (中文解读)</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 3_ Display Tools and Window Leveling-English.html">July 2022 Workshop Video 3_ Display Tools and Window Leveling</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 4_ Image Filtering-Chinese.html">July 2022 Workshop Video 4_ Image Filtering (中文解读)</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 4_ Image Filtering-English.html">July 2022 Workshop Video 4_ Image Filtering</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 5_ Defining Region of Interest (ROI) and Basic Segmentation Tools-Chinese.html">July 2022 Workshop Video 5_ Defining Region of Interest (ROI) and Basic Segmentation Tools (中文解读)</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 5_ Defining Region of Interest (ROI) and Basic Segmentation Tools-English.html">July 2022 Workshop Video 5_ Defining Region of Interest (ROI) and Basic Segmentation Tools</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 6_ Measuring Tools-Chinese.html">July 2022 Workshop Video 6_ Measuring Tools (中文解读)</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 6_ Measuring Tools-English.html">July 2022 Workshop Video 6_ Measuring Tools</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 7_ Image Registration-Chinese.html">July 2022 Workshop Video 7_ Image Registration (中文解读)</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 7_ Image Registration-English.html">July 2022 Workshop Video 7_ Image Registration</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 8_ AI Based Segmentation Part 1-Chinese.html">July 2022 Workshop Video 8_ AI Based Segmentation Part 1 (中文解读)</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 8_ AI Based Segmentation Part 1-English.html">July 2022 Workshop Video 8_ AI Based Segmentation Part 1</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 9_ Segmentation Wizard Part 1-Chinese.html">July 2022 Workshop Video 9_ Segmentation Wizard Part 1 (中文解读)</a></li>
+            <li><a href="videos/Tutorial-July 2022 Workshop Video 9_ Segmentation Wizard Part 1-English.html">July 2022 Workshop Video 9_ Segmentation Wizard Part 1</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Basic Operations-Chinese.html">Learn Dragonfly_ Basic Operations (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Basic Operations-English.html">Learn Dragonfly_ Basic Operations</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Deep Learning Segmentation-Chinese.html">Learn Dragonfly_ Deep Learning Segmentation (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Deep Learning Segmentation-English.html">Learn Dragonfly_ Deep Learning Segmentation</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Image Filtering and Denoising-Chinese.html">Learn Dragonfly_ Image Filtering and Denoising (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Image Filtering and Denoising-English.html">Learn Dragonfly_ Image Filtering and Denoising</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Image Registration-Chinese.html">Learn Dragonfly_ Image Registration (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Image Registration-English.html">Learn Dragonfly_ Image Registration</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Image Segmentation Techniques-Chinese.html">Learn Dragonfly_ Image Segmentation Techniques (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Image Segmentation Techniques-English.html">Learn Dragonfly_ Image Segmentation Techniques</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Importing and Exporting Data-Chinese.html">Learn Dragonfly_ Importing and Exporting Data (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Importing and Exporting Data-English.html">Learn Dragonfly_ Importing and Exporting Data</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Introduction to the User Interface-Chinese.html">Learn Dragonfly_ Introduction to the User Interface (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Introduction to the User Interface-English.html">Learn Dragonfly_ Introduction to the User Interface</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Measurement and Analysis-Chinese.html">Learn Dragonfly_ Measurement and Analysis (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Measurement and Analysis-English.html">Learn Dragonfly_ Measurement and Analysis</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ ROI Creation and Manipulation-Chinese.html">Learn Dragonfly_ ROI Creation and Manipulation (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ ROI Creation and Manipulation-English.html">Learn Dragonfly_ ROI Creation and Manipulation</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Working with Meshes-Chinese.html">Learn Dragonfly_ Working with Meshes (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Learn Dragonfly_ Working with Meshes-English.html">Learn Dragonfly_ Working with Meshes</a></li>
+            <li><a href="videos/Tutorial-Materials Science Applications with Dragonfly Software-Chinese.html">Materials Science Applications with Dragonfly Software (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Materials Science Applications with Dragonfly Software-English.html">Materials Science Applications with Dragonfly Software</a></li>
+            <li><a href="videos/Tutorial-Multi-Scale Correlative Tomography using Dragonfly Software-Chinese.html">Multi Scale Correlative Tomography using Dragonfly Software (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Multi-Scale Correlative Tomography using Dragonfly Software-English.html">Multi Scale Correlative Tomography using Dragonfly Software</a></li>
+            <li><a href="videos/Tutorial-Navigation, slice views, 3D views, and basic interaction-Chinese.html">Navigation, slice views, 3D views, and basic interaction (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Navigation, slice views, 3D views, and basic interaction-English.html">Navigation, slice views, 3D views, and basic interaction</a></li>
+            <li><a href="videos/Tutorial-Neuroscience Research with Dragonfly_ Analyzing Brain Structures-Chinese.html">Neuroscience Research with Dragonfly_ Analyzing Brain Structures (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Neuroscience Research with Dragonfly_ Analyzing Brain Structures-English.html">Neuroscience Research with Dragonfly_ Analyzing Brain Structures</a></li>
+            <li><a href="videos/Tutorial-Porosity Analysis of Casting Components Using Dragonfly-Chinese.html">Porosity Analysis of Casting Components Using Dragonfly (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Porosity Analysis of Casting Components Using Dragonfly-English.html">Porosity Analysis of Casting Components Using Dragonfly</a></li>
+            <li><a href="videos/Tutorial-Python scripting in Dragonfly-Chinese.html">Python scripting in Dragonfly (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Python scripting in Dragonfly-English.html">Python scripting in Dragonfly</a></li>
+            <li><a href="videos/Tutorial-Quantitative Analysis of Fiber Composites with Dragonfly-Chinese.html">Quantitative Analysis of Fiber Composites with Dragonfly (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Quantitative Analysis of Fiber Composites with Dragonfly-English.html">Quantitative Analysis of Fiber Composites with Dragonfly</a></li>
+            <li><a href="videos/Tutorial-ROI tools and their use cases-Chinese.html">ROI tools and their use cases (中文解读)</a></li>
+            <li><a href="videos/Tutorial-ROI tools and their use cases-English.html">ROI tools and their use cases</a></li>
+            <li><a href="videos/Tutorial-Segmentation Part 1_ Thresholding and basic tools-Chinese.html">Segmentation Part 1_ Thresholding and basic tools (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Segmentation Part 1_ Thresholding and basic tools-English.html">Segmentation Part 1_ Thresholding and basic tools</a></li>
+            <li><a href="videos/Tutorial-Segmentation Part 2_Watershed and other automated tools-Chinese.html">Segmentation Part 2_Watershed and other automated tools (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Segmentation Part 2_Watershed and other automated tools-English.html">Segmentation Part 2_Watershed and other automated tools</a></li>
+            <li><a href="videos/Tutorial-Segmentation Part 3_ Deep Learning-Chinese.html">Segmentation Part 3_ Deep Learning (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Segmentation Part 3_ Deep Learning-English.html">Segmentation Part 3_ Deep Learning</a></li>
+            <li><a href="videos/Tutorial-Segmentation of pores in a cast aluminum alloy using Deep Learning-Chinese.html">Segmentation of pores in a cast aluminum alloy using Deep Learning (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Segmentation of pores in a cast aluminum alloy using Deep Learning-English.html">Segmentation of pores in a cast aluminum alloy using Deep Learning</a></li>
+            <li><a href="videos/Tutorial-The Active Contour tool for segmentation-Chinese.html">The Active Contour tool for segmentation (中文解读)</a></li>
+            <li><a href="videos/Tutorial-The Active Contour tool for segmentation-English.html">The Active Contour tool for segmentation</a></li>
+            <li><a href="videos/Tutorial-Using the Image Channel Composition Tool in Dragonfly-Chinese.html">Using the Image Channel Composition Tool in Dragonfly (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Using the Image Channel Composition Tool in Dragonfly-English.html">Using the Image Channel Composition Tool in Dragonfly</a></li>
+            <li><a href="videos/Tutorial-Working with DICOM data in Dragonfly-Chinese.html">Working with DICOM data in Dragonfly (中文解读)</a></li>
+            <li><a href="videos/Tutorial-Working with DICOM data in Dragonfly-English.html">Working with DICOM data in Dragonfly</a></li>
         </ul>
     </div>
 
@@ -431,29 +429,29 @@
             const showAllBtn = document.getElementById('showAllBtn');
             
             let currentLanguageFilter = 'all'; // Default: 'english', 'chinese', 'all'
-            let allTutorials = []; // To be populated once tutorialListUL is confirmed
+            let allTutorials = []; 
 
             if (tutorialListUL) {
                  allTutorials = Array.from(tutorialListUL.getElementsByTagName('li'));
             } else {
                 console.error("Tutorial list #tutorialListUL not found.");
-                return; // Stop if the main list isn't found
+                return; 
             }
 
             function updateActiveButton(activeBtn) {
                 document.querySelectorAll('.lang-toggle-btn').forEach(btn => btn.classList.remove('active'));
-                if (activeBtn) { // Ensure activeBtn is not null
+                if (activeBtn) { 
                     activeBtn.classList.add('active');
                 }
             }
 
             function applyFilters() {
-                const searchTerm = searchInput ? searchInput.value.toLowerCase() : ""; // Handle if searchInput is null
+                const searchTerm = searchInput ? searchInput.value.toLowerCase() : ""; 
                 
                 for (let i = 0; i < allTutorials.length; i++) {
                     const tutorial = allTutorials[i];
                     const link = tutorial.getElementsByTagName('a')[0];
-                    if (!link) continue; // Skip if no link found
+                    if (!link) continue; 
 
                     const title = link.textContent.toLowerCase();
                     let matchesLanguage = false;
@@ -461,12 +459,14 @@
                     if (currentLanguageFilter === 'all') {
                         matchesLanguage = true;
                     } else if (currentLanguageFilter === 'english') {
-                        matchesLanguage = title.includes('(english)');
+                        // Show if the title does NOT contain the Chinese marker
+                        matchesLanguage = !title.includes('(中文解读)');
                     } else if (currentLanguageFilter === 'chinese') {
-                        matchesLanguage = title.includes('(chinese)');
+                        // Show if the title DOES contain the Chinese marker
+                        matchesLanguage = title.includes('(中文解读)');
                     }
                     
-                    const matchesSearch = searchTerm === "" || title.includes(searchTerm); // Show all if search is empty
+                    const matchesSearch = searchTerm === "" || title.includes(searchTerm);
 
                     if (matchesLanguage && matchesSearch) {
                         tutorial.style.display = '';
@@ -512,14 +512,13 @@
                  console.error("Button #showAllBtn not found.");
             }
             
-            // Initial setup
-            if (showAllBtn) { // Check if showAllBtn exists before trying to use it
-                updateActiveButton(showAllBtn); // Set initial active button
-            } else if (document.querySelector('.lang-toggle-btn.active')) { // Fallback if showAllBtn is missing
+            if (showAllBtn) { 
+                updateActiveButton(showAllBtn); 
+            } else if (document.querySelector('.lang-toggle-btn.active')) { 
                 updateActiveButton(document.querySelector('.lang-toggle-btn.active'));
             }
 
-            applyFilters(); // Apply filters on page load
+            applyFilters(); 
         });
     </script>
 </body>

--- a/tutorials/videos/Tutorial-3D Porosity Analysis in Archaeological Ceramics to Reconstruct Production Methods and Performance-English.html
+++ b/tutorials/videos/Tutorial-3D Porosity Analysis in Archaeological Ceramics to Reconstruct Production Methods and Performance-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>3D Porosity Analysis in Archaeological Ceramics to Reconstruct Production Methods and Performance - English Tutorial</title>
+    <title>3D Porosity Analysis in Archaeological Ceramics to Reconstruct Production Methods and Performance</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-A Natural History Perspective_ Micro-CT Scanning at the University of Michigan Museum of Zoology-English.html
+++ b/tutorials/videos/Tutorial-A Natural History Perspective_ Micro-CT Scanning at the University of Michigan Museum of Zoology-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>A Natural History Perspective: Micro-CT Scanning at the University of Michigan Museum of Zoology - English Tutorial</title>
+    <title>A Natural History Perspective: Micro-CT Scanning at the University of Michigan Museum of Zoology</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Additive Manufacturing Powder Characterization Using Dragonfly-Chinese.html
+++ b/tutorials/videos/Tutorial-Additive Manufacturing Powder Characterization Using Dragonfly-Chinese.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Additive Manufacturing Powder Characterization Using Dragonfly - Chinese Tutorial</title>
+    <title>Additive Manufacturing Powder Characterization Using Dragonfly (中文解读)</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Additive Manufacturing Powder Characterization Using Dragonfly-English.html
+++ b/tutorials/videos/Tutorial-Additive Manufacturing Powder Characterization Using Dragonfly-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Additive Manufacturing Powder Characterization Using Dragonfly - English Tutorial</title>
+    <title>Additive Manufacturing Powder Characterization Using Dragonfly</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Automation of NDT Inspection by Dragonfly Scripting and HPC Batch Processing-English.html
+++ b/tutorials/videos/Tutorial-Automation of NDT Inspection by Dragonfly Scripting and HPC Batch Processing-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Automation of NDT Inspection by Dragonfly Scripting and HPC Batch Processing - English Tutorial</title>
+    <title>Automation of NDT Inspection by Dragonfly Scripting and HPC Batch Processing</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-CAD Deviation of Additive Manufacturing Bracket Using Dragonfly-English.html
+++ b/tutorials/videos/Tutorial-CAD Deviation of Additive Manufacturing Bracket Using Dragonfly-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CAD Deviation of Additive Manufacturing Bracket Using Dragonfly - English Tutorial</title>
+    <title>CAD Deviation of Additive Manufacturing Bracket Using Dragonfly</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Computed Tomography for Industrial Inspection and Quality Control Powered by Dragonfly Software-English.html
+++ b/tutorials/videos/Tutorial-Computed Tomography for Industrial Inspection and Quality Control Powered by Dragonfly Software-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Computed Tomography for Industrial Inspection and Quality Control Powered by Dragonfly Software - English Tutorial</title>
+    <title>Computed Tomography for Industrial Inspection and Quality Control Powered by Dragonfly Software</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Cone Beam CT Reconstruction in Dragonfly 2022.2-English.html
+++ b/tutorials/videos/Tutorial-Cone Beam CT Reconstruction in Dragonfly 2022.2-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cone Beam CT Reconstruction in Dragonfly 2022.2 - English Tutorial</title>
+    <title>Cone Beam CT Reconstruction in Dragonfly 2022.2</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Crack Identification and Segmentation for NDT Using Dragonfly How-To Video-Chinese.html
+++ b/tutorials/videos/Tutorial-Crack Identification and Segmentation for NDT Using Dragonfly How-To Video-Chinese.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Crack Identification and Segmentation for NDT Using Dragonfly How-To Video - Chinese Tutorial</title>
+    <title>Crack Identification and Segmentation for NDT Using Dragonfly How-To Video (中文解读)</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Crack Identification and Segmentation for NDT Using Dragonfly How-To Video-English.html
+++ b/tutorials/videos/Tutorial-Crack Identification and Segmentation for NDT Using Dragonfly How-To Video-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Crack Identification and Segmentation for NDT Using Dragonfly How-To Video - English Tutorial</title>
+    <title>Crack Identification and Segmentation for NDT Using Dragonfly How-To Video</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Creating a volume-of-interest using Active Contour tool-Chinese.html
+++ b/tutorials/videos/Tutorial-Creating a volume-of-interest using Active Contour tool-Chinese.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Creating a volume-of-interest using Active Contour tool - Chinese Tutorial</title>
+    <title>Creating a volume-of-interest using Active Contour tool (中文解读)</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Creating a volume-of-interest using Active Contour tool-English.html
+++ b/tutorials/videos/Tutorial-Creating a volume-of-interest using Active Contour tool-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Creating a volume-of-interest using Active Contour tool - English Tutorial</title>
+    <title>Creating a volume-of-interest using Active Contour tool</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Decoding the Fossil Record_ The Benefits of AI in the Segmentation of Fossils-English.html
+++ b/tutorials/videos/Tutorial-Decoding the Fossil Record_ The Benefits of AI in the Segmentation of Fossils-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Decoding the Fossil Record: The Benefits of AI in the Segmentation of Fossils - English Tutorial</title>
+    <title>Decoding the Fossil Record: The Benefits of AI in the Segmentation of Fossils</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Dragonfly 2022.2 Feature _ Volume meshing of a walnut-English.html
+++ b/tutorials/videos/Tutorial-Dragonfly 2022.2 Feature _ Volume meshing of a walnut-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dragonfly 2022.2 Feature : Volume meshing of a walnut - English Tutorial</title>
+    <title>Dragonfly 2022.2 Feature : Volume meshing of a walnut</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Dragonfly 3D World _ AI solutions for individual battery anode-cathode overhang analysis-Chinese.html
+++ b/tutorials/videos/Tutorial-Dragonfly 3D World _ AI solutions for individual battery anode-cathode overhang analysis-Chinese.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dragonfly 3D World | AI solutions for individual battery anode-cathode overhang analysis - Chinese Tutorial</title>
+    <title>Dragonfly 3D World | AI solutions for individual battery anode-cathode overhang analysis (中文解读)</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Dragonfly 3D World _ AI solutions for individual battery anode-cathode overhang analysis-English.html
+++ b/tutorials/videos/Tutorial-Dragonfly 3D World _ AI solutions for individual battery anode-cathode overhang analysis-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dragonfly 3D World | AI solutions for individual battery anode-cathode overhang analysis - English Tutorial</title>
+    <title>Dragonfly 3D World | AI solutions for individual battery anode-cathode overhang analysis</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Dragonfly Daily 35 Workflows, Wizards, and Reports in Dragonfly (2020)-English.html
+++ b/tutorials/videos/Tutorial-Dragonfly Daily 35 Workflows, Wizards, and Reports in Dragonfly (2020)-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dragonfly Daily 35 Workflows, Wizards, and Reports in Dragonfly (2020) - English Tutorial</title>
+    <title>Dragonfly Daily 35 Workflows, Wizards, and Reports in Dragonfly (2020)</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Dragonfly Daily 36 CT Reconstruction in Dragonfly (2020)-English.html
+++ b/tutorials/videos/Tutorial-Dragonfly Daily 36 CT Reconstruction in Dragonfly (2020)-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dragonfly Daily 36 CT Reconstruction in Dragonfly (2020) - English Tutorial</title>
+    <title>Dragonfly Daily 36 CT Reconstruction in Dragonfly (2020)</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Dragonfly Daily 37 Distance Mapping in Dragonfly (2020)-Chinese.html
+++ b/tutorials/videos/Tutorial-Dragonfly Daily 37 Distance Mapping in Dragonfly (2020)-Chinese.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dragonfly Daily 37 Distance Mapping in Dragonfly (2020) - Chinese Tutorial</title>
+    <title>Dragonfly Daily 37 Distance Mapping in Dragonfly (2020) (中文解读)</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Dragonfly Daily 37 Distance Mapping in Dragonfly (2020)-English.html
+++ b/tutorials/videos/Tutorial-Dragonfly Daily 37 Distance Mapping in Dragonfly (2020)-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dragonfly Daily 37 Distance Mapping in Dragonfly (2020) - English Tutorial</title>
+    <title>Dragonfly Daily 37 Distance Mapping in Dragonfly (2020)</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Dragonfly Daily 38 Watershed Transform in Dragonfly (2020)-Chinese.html
+++ b/tutorials/videos/Tutorial-Dragonfly Daily 38 Watershed Transform in Dragonfly (2020)-Chinese.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dragonfly Daily 38 Watershed Transform in Dragonfly (2020) - Chinese Tutorial</title>
+    <title>Dragonfly Daily 38 Watershed Transform in Dragonfly (2020) (中文解读)</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Dragonfly Daily 38 Watershed Transform in Dragonfly (2020)-English.html
+++ b/tutorials/videos/Tutorial-Dragonfly Daily 38 Watershed Transform in Dragonfly (2020)-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dragonfly Daily 38 Watershed Transform in Dragonfly (2020) - English Tutorial</title>
+    <title>Dragonfly Daily 38 Watershed Transform in Dragonfly (2020)</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Dragonfly Daily 39 Cylinder Coordinate Transform in Dragonfly (2020)-English.html
+++ b/tutorials/videos/Tutorial-Dragonfly Daily 39 Cylinder Coordinate Transform in Dragonfly (2020)-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dragonfly Daily 39 Cylinder Coordinate Transform in Dragonfly (2020) - English Tutorial</title>
+    <title>Dragonfly Daily 39 Cylinder Coordinate Transform in Dragonfly (2020)</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-How to use a pretrained deep learning model for additive manufacturing porosity-Chinese.html
+++ b/tutorials/videos/Tutorial-How to use a pretrained deep learning model for additive manufacturing porosity-Chinese.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>How to use a pretrained deep learning model for additive manufacturing porosity - Chinese Tutorial</title>
+    <title>How to use a pretrained deep learning model for additive manufacturing porosity (中文解读)</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-How to use a pretrained deep learning model for additive manufacturing porosity-English.html
+++ b/tutorials/videos/Tutorial-How to use a pretrained deep learning model for additive manufacturing porosity-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>How to use a pretrained deep learning model for additive manufacturing porosity - English Tutorial</title>
+    <title>How to use a pretrained deep learning model for additive manufacturing porosity</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-How-to video_ CT based porosity analysis of concrete using Dragonfly-English.html
+++ b/tutorials/videos/Tutorial-How-to video_ CT based porosity analysis of concrete using Dragonfly-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>How-to video: CT based porosity analysis of concrete using Dragonfly - English Tutorial</title>
+    <title>How-to video: CT based porosity analysis of concrete using Dragonfly</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-How-to video_ CT image analysis for battery inspection using Dragonfly-English.html
+++ b/tutorials/videos/Tutorial-How-to video_ CT image analysis for battery inspection using Dragonfly-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>How-to video: CT image analysis for battery inspection using Dragonfly - English Tutorial</title>
+    <title>How-to video: CT image analysis for battery inspection using Dragonfly</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-Image Import in Dragonfly-English.html
+++ b/tutorials/videos/Tutorial-Image Import in Dragonfly-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Image Import in Dragonfly - English Tutorial</title>
+    <title>Image Import in Dragonfly</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-In Vivo and Specimen Imaging at the Center for Molecular and Genomic Imaging-English.html
+++ b/tutorials/videos/Tutorial-In Vivo and Specimen Imaging at the Center for Molecular and Genomic Imaging-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>In Vivo and Specimen Imaging at the Center for Molecular and Genomic Imaging - English Tutorial</title>
+    <title>In Vivo and Specimen Imaging at the Center for Molecular and Genomic Imaging</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-July 2022 Workshop Video 0_ Introduction-English.html
+++ b/tutorials/videos/Tutorial-July 2022 Workshop Video 0_ Introduction-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>July 2022 Workshop Video 0: Introduction - English Tutorial</title>
+    <title>July 2022 Workshop Video 0: Introduction</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-July 2022 Workshop Video 10_ Segmentation Wizard Part 2-English.html
+++ b/tutorials/videos/Tutorial-July 2022 Workshop Video 10_ Segmentation Wizard Part 2-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>July 2022 Workshop Video 10: Segmentation Wizard Part 2 - English Tutorial</title>
+    <title>July 2022 Workshop Video 10: Segmentation Wizard Part 2</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>

--- a/tutorials/videos/Tutorial-July 2022 Workshop Video 11_ Deep learning tool-English.html
+++ b/tutorials/videos/Tutorial-July 2022 Workshop Video 11_ Deep learning tool-English.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>July 2022 Workshop Video 11: Deep learning tool - English Tutorial</title>
+    <title>July 2022 Workshop Video 11: Deep learning tool</title>
     <link rel="stylesheet" href="/dragonfly3dworld/design.css">
     <link href="https://cdn.jsdelivr.net/npm/HarmonyOS_Sans_SC@1.0.3/HarmonyOS_Sans_SC.min.css" rel="stylesheet"/>
     <style>


### PR DESCRIPTION
This commit implements the following changes:

1.  **Video HTML Title Modification**:
    - Processed HTML files in `tutorials/videos/`.
    - For files with titles ending in " - English Tutorial", this suffix was removed from their `<title>` tag.
    - For files with titles ending in " - Chinese Tutorial", this suffix was replaced with " (中文解读)" in their `<title>` tag.
    - Files using `{{ title }}` templates or not matching these suffixes were not changed.
    - This standardizes the display of titles in browser tabs/windows.

2.  **Tutorial Index Page (`tutorials/index.html`) Updates**:
    - The static link text for each video in the list has been updated to reflect the new title conventions: - English video links no longer show an "(English)" suffix. - Chinese video links now show a "(中文解读)" suffix.
    - The JavaScript filtering logic for the language toggle buttons ("Show English Only", "Show Chinese Only", "Show All") has been updated to work with the new link text format. "English" videos are now identified by the *absence* of "(中文解读)" in their link text.

These changes ensure consistency in how video titles are presented and improve the accuracy of the language filtering feature on the tutorial index page.